### PR TITLE
feat: substitute executables at the build time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "ufcs",
- "which",
  "xdg",
 ]
 
@@ -677,17 +676,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "which"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
-dependencies = [
- "either",
- "libc",
- "once_cell",
-]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,6 @@ authors = ["Albert Safin <xzfcpw@gmail.com>"]
 license = "Unlicense OR MIT"
 edition = "2018"
 
-[build-dependencies]
-which = "4.4.0"
-
 [dependencies]
 blake3 = "1.3.3"
 bytelines = "2.4.0"

--- a/build.rs
+++ b/build.rs
@@ -5,18 +5,28 @@ use std::process::Command;
 fn main() {
     // Necessary env var to substitute in the final artifact depends on, regardless of the
     // build context; either in nix-shell or a basic nix build.
-    println!(
-        "cargo:rustc-env=CNS_ESSENTIALS={}",
-        var("ESSENTIALS").expect("Expect to the ESSENTIALS env var to be set.")
-    );
-    println!(
-        "cargo:rustc-env=CNS_BASH={}",
-        var("BASH").expect("Expect to the BASH env var to be set.")
-    );
-    println!(
-        "cargo:rustc-env=CNS_NIX={}/",
-        var("NIX_BIN").expect("Expect to the NIX_BIN env var to be set.")
-    );
+
+    // We need to support non-nix environment anyways, ecpesially for VSCode and rust-analyser that 
+    // is being run by a VSCode extension and it doesn't have access to nix-shell to do a proper build.
+    if var("IN_NIX").is_err() || var("IN_NIX").unwrap() != "1" {
+        println!("cargo:rustc-env=CNS_ESSENTIALS=/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin:/opt/homebrew/bin:/opt/homebrew/sbin");
+        println!("cargo:rustc-env=CNS_BASH=bash");
+        println!("cargo:rustc-env=CNS_NIX=");
+    } else {
+        println!(
+            "cargo:rustc-env=CNS_ESSENTIALS={}",
+            var("ESSENTIALS")
+                .expect("Expect to the ESSENTIALS env var to be set.")
+        );
+        println!(
+            "cargo:rustc-env=CNS_BASH={}",
+            var("BASH").expect("Expect to the BASH env var to be set.")
+        );
+        println!(
+            "cargo:rustc-env=CNS_NIX={}/",
+            var("NIX_BIN").expect("Expect to the NIX_BIN env var to be set.")
+        );
+    }
 
     if var_os("CNS_IN_NIX_SHELL").is_none() {
         // Release build triggered by nix-build. Use paths relative to $out.

--- a/default.nix
+++ b/default.nix
@@ -1,17 +1,20 @@
-{ pkgs ? import <nixpkgs> { }, nix ? pkgs.nix }:
+let sources = import ./nix/sources.nix;
+in { pkgs ? import sources.nixpkgs { } }:
+
 let
-  sources = import ./nix/sources.nix;
   naersk = pkgs.callPackage sources.naersk { };
   gitignoreSource = (pkgs.callPackage sources.gitignore { }).gitignoreSource;
   blake3-src = sources.BLAKE3;
-in (naersk.buildPackage {
+in
+(naersk.buildPackage {
   root = gitignoreSource ./.;
-  buildInputs = [ pkgs.openssl nix pkgs.ronn ];
+  buildInputs = [ pkgs.openssl pkgs.nix pkgs.ronn ];
 }).overrideAttrs (attrs: {
-  CNS_GIT_COMMIT = if builtins.pathExists ./.git then
-    pkgs.lib.commitIdFromGitRepo ./.git
-  else
-    "next";
+  CNS_GIT_COMMIT =
+    if builtins.pathExists ./.git then
+      pkgs.lib.commitIdFromGitRepo ./.git
+    else
+      "next";
   BLAKE3_CSRC = "${blake3-src}/c";
   postBuild = "make -f nix/Makefile post-build";
   postInstall = "make -f nix/Makefile post-install";

--- a/default.nix
+++ b/default.nix
@@ -6,22 +6,24 @@ let
   gitignoreSource = (pkgs.callPackage sources.gitignore { }).gitignoreSource;
   blake3-src = sources.BLAKE3;
 
+  ESSENTIALS = with pkgs;
+    lib.makeBinPath [ bashInteractive coreutils nix gitMinimal gnutar gzip ];
+  BASH = "${pkgs.bashInteractive}/bin/bash";
+  NIX_BIN = "${pkgs.nix}/bin";
+
   # The main cached-nix-shell package. It's subject for override (see below) of the 
   # underlying derivation attributes so the build works correctly.
   package = naersk.buildPackage {
     root = gitignoreSource ./.;
-    buildInputs = with pkgs; [
-      openssl
-      nix
-      ronn
-    ];
+    buildInputs = with pkgs; [ openssl nix ronn ];
   };
   # Final overrides.
   package' = package.overrideAttrs (_: {
-    CNS_GIT_COMMIT =
-      if builtins.pathExists ./.git
-      then pkgs.lib.commitIdFromGitRepo ./.git
-      else "next";
+    inherit ESSENTIALS BASH NIX_BIN;
+    CNS_GIT_COMMIT = if builtins.pathExists ./.git then
+      pkgs.lib.commitIdFromGitRepo ./.git
+    else
+      "next";
     BLAKE3_CSRC = "${blake3-src}/c";
     postBuild = ''
       make -f nix/Makefile post-build
@@ -30,5 +32,4 @@ let
       make -f nix/Makefile post-install
     '';
   });
-in
-package'
+in package'

--- a/default.nix
+++ b/default.nix
@@ -5,17 +5,30 @@ let
   naersk = pkgs.callPackage sources.naersk { };
   gitignoreSource = (pkgs.callPackage sources.gitignore { }).gitignoreSource;
   blake3-src = sources.BLAKE3;
+
+  # The main cached-nix-shell package. It's subject for override (see below) of the 
+  # underlying derivation attributes so the build works correctly.
+  package = naersk.buildPackage {
+    root = gitignoreSource ./.;
+    buildInputs = with pkgs; [
+      openssl
+      nix
+      ronn
+    ];
+  };
+  # Final overrides.
+  package' = package.overrideAttrs (_: {
+    CNS_GIT_COMMIT =
+      if builtins.pathExists ./.git
+      then pkgs.lib.commitIdFromGitRepo ./.git
+      else "next";
+    BLAKE3_CSRC = "${blake3-src}/c";
+    postBuild = ''
+      make -f nix/Makefile post-build
+    '';
+    postInstall = ''
+      make -f nix/Makefile post-install
+    '';
+  });
 in
-(naersk.buildPackage {
-  root = gitignoreSource ./.;
-  buildInputs = [ pkgs.openssl pkgs.nix pkgs.ronn ];
-}).overrideAttrs (attrs: {
-  CNS_GIT_COMMIT =
-    if builtins.pathExists ./.git then
-      pkgs.lib.commitIdFromGitRepo ./.git
-    else
-      "next";
-  BLAKE3_CSRC = "${blake3-src}/c";
-  postBuild = "make -f nix/Makefile post-build";
-  postInstall = "make -f nix/Makefile post-install";
-})
+package'

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,11 @@
-let sources = import ./nix/sources.nix;
+let
+  sources = import ./nix/sources.nix;
+  minNixVer = "2.4";
 in { pkgs ? import sources.nixpkgs { } }:
+
+assert pkgs.lib.assertMsg
+  (builtins.compareVersions minNixVer pkgs.nix.version != 1)
+  "The project doesn't support Nix of version ${pkgs.nix.version}. The minimum required version is ${minNixVer}.";
 
 let
   naersk = pkgs.callPackage sources.naersk { };
@@ -10,6 +16,7 @@ let
     lib.makeBinPath [ bashInteractive coreutils nix gitMinimal gnutar gzip ];
   BASH = "${pkgs.bashInteractive}/bin/bash";
   NIX_BIN = "${pkgs.nix}/bin";
+  IN_NIX = true;
 
   # The main cached-nix-shell package. It's subject for override (see below) of the 
   # underlying derivation attributes so the build works correctly.
@@ -19,7 +26,7 @@ let
   };
   # Final overrides.
   package' = package.overrideAttrs (_: {
-    inherit ESSENTIALS BASH NIX_BIN;
+    inherit ESSENTIALS BASH NIX_BIN IN_NIX;
     CNS_GIT_COMMIT = if builtins.pathExists ./.git then
       pkgs.lib.commitIdFromGitRepo ./.git
     else

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -34,5 +34,17 @@
         "type": "tarball",
         "url": "https://github.com/nmattia/naersk/archive/88cd22380154a2c36799fe8098888f0f59861a15.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "nixpkgs": {
+        "branch": "nixpkgs-unstable",
+        "description": "Nix Packages collection & NixOS",
+        "homepage": "",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "63143ac2c9186be6d9da6035fa22620018c85932",
+        "sha256": "1qvr6c7sisnzvcnyidllsv0bz0xsjfw3cg5s090y3az6sgrrlss0",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/63143ac2c9186be6d9da6035fa22620018c85932.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -18,7 +18,7 @@ in mkShell {
     git
     openssh
   ];
-  inherit (main) ESSENTIALS BASH NIX_BIN BLAKE3_CSRC;
+  inherit (main) ESSENTIALS BASH NIX_BIN IN_NIX BLAKE3_CSRC;
   CNS_IN_NIX_SHELL = "1";
   RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,11 @@
-{ pkgs ? import <nixpkgs> { } }:
-let main = import ./default.nix { inherit pkgs; };
-in with pkgs;
+let sources = import ./nix/sources.nix;
+in { pkgs ? import sources.nixpkgs { } }:
+
+with pkgs;
+
+let
+  main = import ./default.nix { inherit pkgs; };
+in
 mkShell {
   buildInputs = main.buildInputs ++ main.nativeBuildInputs ++ [
     cargo-edit

--- a/shell.nix
+++ b/shell.nix
@@ -3,10 +3,8 @@ in { pkgs ? import sources.nixpkgs { } }:
 
 with pkgs;
 
-let
-  main = import ./default.nix { inherit pkgs; };
-in
-mkShell {
+let main = import ./default.nix { inherit pkgs; };
+in mkShell {
   buildInputs = main.buildInputs ++ main.nativeBuildInputs ++ [
     cargo-edit
     clippy
@@ -20,7 +18,7 @@ mkShell {
     git
     openssh
   ];
-  inherit (main) BLAKE3_CSRC;
+  inherit (main) ESSENTIALS BASH NIX_BIN BLAKE3_CSRC;
   CNS_IN_NIX_SHELL = "1";
   RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -10,6 +10,7 @@
 //! compatible way, so it is appropriate to code this explicitly rather than use
 //! such libraries.
 
+use log::info;
 use std::collections::VecDeque;
 use std::ffi::{OsStr, OsString};
 use std::io::Write;
@@ -17,7 +18,6 @@ use std::os::unix::ffi::OsStrExt;
 use std::os::unix::process::CommandExt;
 use std::process::{exit, Command};
 use ufcs::Pipe;
-use log::info;
 
 pub enum RunMode {
     /// no arg
@@ -97,7 +97,7 @@ impl Args {
             packages_or_expr: false,
             pure: false,
             include_nix_path: Vec::new(),
-            interpreter: OsString::from("bash"),
+            interpreter: env!("CNS_BASH").into(),
             run: RunMode::InteractiveShell,
             keep: Vec::new(),
             rest: Vec::new(),
@@ -204,11 +204,6 @@ fn exit_version() {
             .map(|x| format!("-{x}"))
             .unwrap_or("".into())
     );
-    if env!("CNS_NIX").is_empty() {
-        info!("Using nix-shell from $PATH");
-    } else {
-        info!("Using {}nix-shell", env!("CNS_NIX"));
-    }
     std::io::stdout().flush().unwrap();
     Command::new(concat!(env!("CNS_NIX"), "nix-shell"))
         .arg("--version")

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,12 @@ use crate::args::Args;
 use crate::bash::is_literal_bash_string;
 use crate::path_clean::PathClean;
 use crate::trace::Trace;
+use env_logger::{Builder, Env};
 use itertools::{chain, Itertools};
+use log::{debug, error, info, warn};
 use nix::unistd::{access, AccessFlags};
 use once_cell::sync::Lazy;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::env::current_dir;
 use std::ffi::{OsStr, OsString};
 use std::fs::{read, read_link, File};
@@ -19,8 +21,6 @@ use std::process::{exit, Command, Stdio};
 use std::time::Instant;
 use tempfile::NamedTempFile;
 use ufcs::Pipe;
-use log::{debug, error, warn,  info};
-use env_logger::{Builder, Env};
 
 mod args;
 mod bash;
@@ -109,50 +109,6 @@ struct NixShellOutput {
     drv: String,
 }
 
-fn minimal_essential_path() -> OsString {
-    let required_binaries = ["tar", "gzip", "git", "nix-shell", "rm"];
-
-    fn which_dir(binary: &&str) -> Option<PathBuf> {
-        std::env::var_os("PATH")
-            .as_ref()
-            .unwrap()
-            .pipe(std::env::split_paths)
-            .find(|dir| {
-                if access(&dir.join(binary), AccessFlags::X_OK).is_err() {
-                    return false;
-                }
-
-                if binary == &"nix-shell" {
-                    // Ignore our fake nix-shell.
-                    return !dir
-                        .join(binary)
-                        .canonicalize()
-                        .ok()
-                        .and_then(|x| x.file_name().map(|x| x.to_os_string()))
-                        .map(|x| x == "cached-nix-shell")
-                        .unwrap_or(true);
-                }
-
-                true
-            })
-    }
-
-    let required_paths = required_binaries
-        .iter()
-        .filter_map(which_dir)
-        .collect::<HashSet<PathBuf>>();
-
-    // We can't just join_paths(required_paths) -- we need to preserve order
-    std::env::var_os("PATH")
-        .as_ref()
-        .unwrap()
-        .pipe(std::env::split_paths)
-        .filter(|path_item| required_paths.contains(path_item))
-        .unique()
-        .pipe(std::env::join_paths)
-        .unwrap()
-}
-
 fn absolute_dirname(script_fname: &OsStr) -> PathBuf {
     Path::new(&script_fname)
         .parent()
@@ -209,13 +165,15 @@ fn args_to_inp(pwd: PathBuf, x: &Args) -> NixShellInput {
                 args.push(var.clone());
             }
         }
-        clean_env.insert(OsString::from("PATH"), minimal_essential_path());
+        clean_env.insert(OsString::from("PATH"), env!("CNS_ESSENTIALS").into());
         clean_env
     };
 
     args.extend(x.other_kw.clone());
     args.push(OsString::from("--"));
     args.extend(x.rest.clone());
+
+    debug!("env: {:?}", &env);
 
     NixShellInput {
         pwd,
@@ -307,9 +265,7 @@ fn run_nix_shell(inp: &NixShellInput) -> NixShellOutput {
             stderr.extend(exec.stderr);
         }
         if !exec.status.success() {
-            error!(
-                "failed to execute nix show-derivation"
-            );
+            error!("failed to execute nix show-derivation");
             let _ = std::io::stderr().write_all(&stderr);
             exit(1);
         }
@@ -350,7 +306,7 @@ fn run_script(
         exec_string.push("exec ");
         exec_string.push(nix_shell_args.interpreter);
         exec_string.push(r#" "$@""#);
-        Command::new("bash")
+        Command::new(env!("CNS_BASH"))
             .arg("-c")
             .arg(exec_string)
             .arg("cached-nix-shell-bash") // corresponds to "$0" inside '-i'
@@ -428,12 +384,12 @@ fn run_from_args(args: Vec<OsString>) {
         args::RunMode::InteractiveShell => {
             let mut args = vec!["--rcfile".into(), env!("CNS_RCFILE").into()];
             args.append(build_bash_options(&env).as_mut());
-            ("bash".into(), args)
+            (env!("CNS_BASH").into(), args)
         }
         args::RunMode::Shell(cmd) => {
             let mut args = build_bash_options(&env);
             args.extend_from_slice(&["-c".into(), cmd]);
-            ("bash".into(), args)
+            (env!("CNS_BASH").into(), args)
         }
         args::RunMode::Exec(cmd, cmd_args) => (cmd, cmd_args),
     };
@@ -636,7 +592,7 @@ fn wrap(cmd: Vec<OsString>) {
         .args(&cmd[1..])
         .env("PATH", OsStr::from_bytes(&new_path))
         .exec();
-    error!("couldn't run: {exec}");
+    error!("couldn't execute: {exec}");
     exit(1);
 }
 

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,10 +1,10 @@
 use itertools::Itertools;
+use log::info;
 use std::collections::BTreeMap;
 use std::ffi::{OsStr, OsString};
 use std::fs::{read, read_dir, read_link, symlink_metadata};
 use std::io::ErrorKind;
 use std::os::unix::ffi::OsStrExt;
-use log::error;
 
 /// Output of trace-nix.so, sorted and deduplicated.
 pub struct Trace {
@@ -81,7 +81,7 @@ fn check_item_updated(k: &[u8], v: &[u8]) -> bool {
     };
 
     if res.as_bytes() != v {
-        error!(
+        info!(
             "{:?}: expected {:?}, got {:?}",
             fname,
             OsStr::from_bytes(v),


### PR DESCRIPTION
## Motivation

Currently, the main process [does runtime lookups](https://github.com/olebedev/cached-nix-shell/blob/25587b5/src/main.rs#L110-L152) for essential executables, along with trying to execute `bash`, `nix` and `nix-shell` that re available in the `$PATH`, which can lead to non deterministic behavior. 

In this PR I pin all the executable that the `cached-nix-shell` ever depend on at the build time, via Nix and cargo features when use `build.rs` files.

## TODO

Change the merge base once the first `oleg/add-logger` PR is merged.

---

cc @fwouts