### PR TITLE
feat: disable bash session history

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ fn main() {
     // Necessary env var to substitute in the final artifact depends on, regardless of the
     // build context; either in nix-shell or a basic nix build.
 
-    // We need to support non-nix environment anyways, ecpesially for VSCode and rust-analyser that 
+    // We need to support non-nix environment anyways, especially for VSCode and rust-analyser that
     // is being run by a VSCode extension and it doesn't have access to nix-shell to do a proper build.
     if var("IN_NIX").is_err() || var("IN_NIX").unwrap() != "1" {
         println!("cargo:rustc-env=CNS_ESSENTIALS=/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin:/opt/homebrew/bin:/opt/homebrew/sbin");

--- a/src/main.rs
+++ b/src/main.rs
@@ -422,6 +422,16 @@ fn cached_shell_env(pure: bool, inp: &NixShellInput) -> EnvOptions {
     let bashopts = env.remove(OsStr::new("BASHOPTS")).unwrap_or_default();
     env.insert(OsString::from("IN_CACHED_NIX_SHELL"), OsString::from("1"));
 
+    // Disable bash session history. See https://superuser.com/a/1400695 for details.
+    // Also, see /etc/bashrc_Apple_Terminal, to look at the script that does lookups for the
+    // SHELL_SESSION_DID_INIT env var.
+    if std::env::var("CNS_DONT_SET_SHELL_SESSION_DID_INIT").is_err() {
+        env.insert(
+            OsString::from("SHELL_SESSION_DID_INIT"),
+            OsString::from("1"),
+        );
+    }
+
     EnvOptions {
         env: merge_env(if pure { env } else { merge_impure_env(env) }),
         shellopts,


### PR DESCRIPTION
## Motivation

By default on Apple device in the Apple Terminal the bash process will print things like:
```
Saving session...
...copying shared history...
...saving history...truncating history files...
...completed.
```

This PR disables that behavior via setting `SHELL_SESSION_DID_INIT=1` env var that is being looked up in the `/etc/bashrc_Apple_Terminal` script that is sourced in `/ect/bashrc` by default for that terminal application.

## TODO

Change the merge base once the second PR from the `oleg/lock-executables` branch is merged.

cc @fwouts

